### PR TITLE
Fix for attribute import statistics

### DIFF
--- a/server/openstorefront/openstorefront-core/service/src/main/java/edu/usu/sdl/openstorefront/service/io/reader/CSVReader.java
+++ b/server/openstorefront/openstorefront-core/service/src/main/java/edu/usu/sdl/openstorefront/service/io/reader/CSVReader.java
@@ -36,6 +36,7 @@ public class CSVReader
 	public String[] nextRecord()
 	{
 		try {
+			currentRecordNumber++;
 			return reader.readNext();
 		} catch (IOException ex) {
 			throw new OpenStorefrontRuntimeException(ex);


### PR DESCRIPTION
The currentRecordNumber must be up-to-date for the UI to reflect the
proper numbers of stored / processed / total.