### PR TITLE
STORE-846 Can't delete special characters entry from System Config Properties

### DIFF
--- a/server/openstorefront/openstorefront-web/src/main/webapp/WEB-INF/securepages/admin/application/system.jsp
+++ b/server/openstorefront/openstorefront-web/src/main/webapp/WEB-INF/securepages/admin/application/system.jsp
@@ -963,7 +963,7 @@
 
 				var deleteSysConfigProp = function deleteSysConfigProp(record) {
 					var url = '/openstorefront/api/v1/service/application/configproperties/';
-					url += record.data.code;
+					url += encodeURIComponent(record.data.code);
 
 					Ext.Ajax.request({
 						url: url,


### PR DESCRIPTION
This resolves STORE-846, where a user is unable to delete a property
with special characters in the key.