### PR TITLE
STORE-808 Restricting Attributes to Specific Types

### DIFF
--- a/server/openstorefront/openstorefront-core/model/src/main/java/edu/usu/sdl/openstorefront/core/entity/AttributeType.java
+++ b/server/openstorefront/openstorefront-core/model/src/main/java/edu/usu/sdl/openstorefront/core/entity/AttributeType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Space Dynamics Laboratory - Utah State University Research Foundation.
+ * Copyright 2016 Space Dynamics Laboratory - Utah State University Research Foundation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,10 +34,6 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import org.apache.commons.lang3.StringUtils;
 
-/**
- *
- * @author jlaw
- */
 @APIDescription("Allows for grouping the metadata into categories")
 public class AttributeType
 		extends StandardEntity
@@ -75,6 +71,12 @@ public class AttributeType
 	@ConsumeField
 	@OneToMany(orphanRemoval = true)
 	private List<ComponentTypeRestriction> requiredRestrictions;
+
+	@DataType(ComponentTypeRestriction.class)
+	@ConsumeField
+	@APIDescription("The component/entry types for which this attribute is available")
+	@OneToMany(orphanRemoval = true)
+	private List<ComponentTypeRestriction> associatedComponentTypes;
 
 	@NotNull
 	@ConsumeField
@@ -125,6 +127,7 @@ public class AttributeType
 		this.setHideOnSubmission(attributeTypeUpdate.getHideOnSubmission());
 		this.setDefaultAttributeCode(attributeTypeUpdate.getDefaultAttributeCode());
 		this.setRequiredRestrictions(attributeTypeUpdate.getRequiredRestrictions());
+		this.setAssociatedComponentTypes(attributeTypeUpdate.getAssociatedComponentTypes());
 
 	}
 
@@ -279,6 +282,16 @@ public class AttributeType
 	public void setRequiredRestrictions(List<ComponentTypeRestriction> requiredRestrictions)
 	{
 		this.requiredRestrictions = requiredRestrictions;
+	}
+
+	public List<ComponentTypeRestriction> getAssociatedComponentTypes()
+	{
+		return associatedComponentTypes;
+	}
+
+	public void setAssociatedComponentTypes(List<ComponentTypeRestriction> associatedComponentTypes)
+	{
+		this.associatedComponentTypes = associatedComponentTypes;
 	}
 
 }

--- a/server/openstorefront/openstorefront-core/model/src/main/java/edu/usu/sdl/openstorefront/core/view/AttributeTypeSave.java
+++ b/server/openstorefront/openstorefront-core/model/src/main/java/edu/usu/sdl/openstorefront/core/view/AttributeTypeSave.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 Space Dynamics Laboratory - Utah State University Research Foundation.
+ * Copyright 2016 Space Dynamics Laboratory - Utah State University Research Foundation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ import java.util.List;
 /**
  * Helper to workaround moxy binding issue
  *
- * @author dshurtleff
  */
 public class AttributeTypeSave
 {
@@ -36,6 +35,10 @@ public class AttributeTypeSave
 	@DataType(ComponentTypeRestriction.class)
 	@ConsumeField
 	private List<ComponentTypeRestriction> componentTypeRestrictions = new ArrayList<>();
+
+	@DataType(ComponentTypeRestriction.class)
+	@ConsumeField
+	private List<ComponentTypeRestriction> associatedComponentTypes = new ArrayList<>();
 
 	public AttributeTypeSave()
 	{
@@ -59,6 +62,16 @@ public class AttributeTypeSave
 	public void setComponentTypeRestrictions(List<ComponentTypeRestriction> componentTypeRestrictions)
 	{
 		this.componentTypeRestrictions = componentTypeRestrictions;
+	}
+
+	public List<ComponentTypeRestriction> getAssociatedComponentTypes()
+	{
+		return associatedComponentTypes;
+	}
+
+	public void setAssociatedComponentTypes(List<ComponentTypeRestriction> associatedComponentTypes)
+	{
+		this.associatedComponentTypes = associatedComponentTypes;
 	}
 
 }

--- a/server/openstorefront/openstorefront-core/model/src/main/java/edu/usu/sdl/openstorefront/core/view/AttributeTypeView.java
+++ b/server/openstorefront/openstorefront-core/model/src/main/java/edu/usu/sdl/openstorefront/core/view/AttributeTypeView.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 Space Dynamics Laboratory - Utah State University Research Foundation.
+ * Copyright 2016 Space Dynamics Laboratory - Utah State University Research Foundation.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,10 +23,6 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.validation.constraints.NotNull;
 
-/**
- *
- * @author dshurtleff
- */
 public class AttributeTypeView
 		extends StandardEntityView
 {
@@ -67,6 +63,9 @@ public class AttributeTypeView
 	@DataType(ComponentTypeRestriction.class)
 	private List<ComponentTypeRestriction> requiredRestrictions = new ArrayList<>();
 
+	@DataType(ComponentTypeRestriction.class)
+	private List<ComponentTypeRestriction> associatedComponentTypes = new ArrayList<>();
+
 	public AttributeTypeView()
 	{
 	}
@@ -86,9 +85,11 @@ public class AttributeTypeView
 		attributeTypeView.setDefaultAttributeCode(attributeType.getDefaultAttributeCode());
 		attributeTypeView.setActiveStatus(attributeType.getActiveStatus());
 		attributeTypeView.setRequiredRestrictions(attributeType.getRequiredRestrictions());
+		attributeTypeView.setAssociatedComponentTypes(attributeType.getAssociatedComponentTypes());
 		attributeTypeView.toStandardView(attributeType);
 
 		return attributeTypeView;
+
 	}
 
 	public String getAttributeType()
@@ -224,6 +225,16 @@ public class AttributeTypeView
 	public void setRequiredRestrictions(List<ComponentTypeRestriction> requiredRestrictions)
 	{
 		this.requiredRestrictions = requiredRestrictions;
+	}
+
+	public List<ComponentTypeRestriction> getAssociatedComponentTypes()
+	{
+		return associatedComponentTypes;
+	}
+
+	public void setAssociatedComponentTypes(List<ComponentTypeRestriction> associatedComponentTypes)
+	{
+		this.associatedComponentTypes = associatedComponentTypes;
 	}
 
 }

--- a/server/openstorefront/openstorefront-web/src/main/java/edu/usu/sdl/openstorefront/web/rest/resource/AttributeResource.java
+++ b/server/openstorefront/openstorefront-web/src/main/java/edu/usu/sdl/openstorefront/web/rest/resource/AttributeResource.java
@@ -389,6 +389,14 @@ public class AttributeResource
 		} else if (attributeTypeSave.getComponentTypeRestrictions() == null) {
 			attributeType.setRequiredRestrictions(attributeTypeSave.getComponentTypeRestrictions());
 		}
+
+		if (attributeTypeSave.getAssociatedComponentTypes() != null
+				&& attributeTypeSave.getAssociatedComponentTypes().isEmpty() == false) {
+			attributeType.setAssociatedComponentTypes(attributeTypeSave.getAssociatedComponentTypes());
+		} else if (attributeTypeSave.getAssociatedComponentTypes() == null) {
+			attributeType.setAssociatedComponentTypes(attributeTypeSave.getAssociatedComponentTypes());
+		}
+
 		return handleAttributePostPutType(attributeType, true);
 	}
 

--- a/server/openstorefront/openstorefront-web/src/main/java/edu/usu/sdl/openstorefront/web/rest/resource/AttributeResource.java
+++ b/server/openstorefront/openstorefront-web/src/main/java/edu/usu/sdl/openstorefront/web/rest/resource/AttributeResource.java
@@ -419,6 +419,12 @@ public class AttributeResource
 			} else if (attributeTypeSave.getComponentTypeRestrictions() == null) {
 				attributeType.setRequiredRestrictions(attributeTypeSave.getComponentTypeRestrictions());
 			}
+			if (attributeTypeSave.getAssociatedComponentTypes() != null
+					&& attributeTypeSave.getAssociatedComponentTypes().isEmpty() == false) {
+				attributeType.setAssociatedComponentTypes(attributeTypeSave.getAssociatedComponentTypes());
+			} else if (attributeTypeSave.getAssociatedComponentTypes() == null) {
+				attributeType.setAssociatedComponentTypes(attributeTypeSave.getAssociatedComponentTypes());
+			}
 			attributeType.setAttributeType(type);
 			return handleAttributePostPutType(attributeType, true);
 		} else {

--- a/server/openstorefront/openstorefront-web/src/main/webapp/WEB-INF/securepages/admin/data/attributes.jsp
+++ b/server/openstorefront/openstorefront-web/src/main/webapp/WEB-INF/securepages/admin/data/attributes.jsp
@@ -541,7 +541,7 @@
 								handler: function () {
 									var record = codesGrid.getSelection()[0];
 									var title = 'Delete Code';
-									var msg = 'Are you sure you want to delete this code?'
+									var msg = 'Are you sure you want to delete this code?';
 									Ext.MessageBox.confirm(title, msg, function (btn) {
 										if (btn === 'yes') {
 											actionDeleteCode(record);
@@ -891,6 +891,50 @@
 							},
 							{
 								xtype: 'panel',
+								html: '<b>Associated Entry Types:</b>'
+							},
+							{
+								xtype: 'checkboxfield',
+								boxLabel: 'Allow For All Entry Types',
+								value: true,
+								handler: function(box, value) {
+									if (value) {
+										Ext.getCmp('editAttributeForm-associatedComponentTypes').hide();
+									} else {
+										Ext.getCmp('editAttributeForm-associatedComponentTypes').show();
+									}
+								}
+							},
+							{
+								xtype: 'multiselector',
+								id: 'editAttributeForm-associatedComponentTypes',
+								hidden: true,
+								style: {
+									margin: '30px'
+								},
+								title: 'Allow For Entry Types (click plus icon to add)',
+								name: 'allowForEntryTypes',
+								fieldName: 'description',
+								fieldTitle: 'Entry Type',
+								viewConfig: {
+									deferEmptyText: false,
+									emptyText: 'No entry types selected. If no entry types are selected, all entries will allow this attribute.'
+								},
+								search: {
+									field: 'description',
+									flex: 1,
+									store: {
+										id: 'allowForTypesSearchStore',
+										proxy: {
+											type: 'ajax',
+											url: '../api/v1/resource/componenttypes/lookup'												
+										},
+										autoLoad: true
+									}
+								}
+							},
+							{
+								xtype: 'panel',
 								html: '<b>Flags:</b>'
 							},
 							{
@@ -986,7 +1030,7 @@
 										autoLoad: true
 									}
 								}
-							}
+							},
 						],
 						dockedItems: [
 							{

--- a/server/openstorefront/openstorefront-web/src/main/webapp/WEB-INF/securepages/admin/data/attributes.jsp
+++ b/server/openstorefront/openstorefront-web/src/main/webapp/WEB-INF/securepages/admin/data/attributes.jsp
@@ -923,16 +923,17 @@
 									emptyText: 'No entry types selected. If no entry types are selected, all entries will allow this attribute.'
 								},
 								search: {
+									id: 'allowForTypesSearch',
 									field: 'description',
 									flex: 1,
-									store: {
+									store: Ext.create('Ext.data.Store', {
 										id: 'allowForTypesSearchStore',
 										proxy: {
 											type: 'ajax',
 											url: '../api/v1/resource/componenttypes/lookup'												
 										},
 										autoLoad: true
-									}
+									})
 								}
 							},
 							{
@@ -1023,14 +1024,14 @@
 								search: {
 									field: 'description',
 									flex: 1,
-									store: {
+									store: Ext.create('Ext.data.Store', {
 										id: 'requiredTypesSearchStore',
 										proxy: {
 											type: 'ajax',
 											url: '../api/v1/resource/componenttypes/lookup'												
 										},
 										autoLoad: true
-									}
+									})
 								}
 							},
 						],

--- a/server/openstorefront/openstorefront-web/src/main/webapp/WEB-INF/securepages/admin/data/attributes.jsp
+++ b/server/openstorefront/openstorefront-web/src/main/webapp/WEB-INF/securepages/admin/data/attributes.jsp
@@ -290,13 +290,16 @@
 				Ext.getCmp('editAttributeForm-defaultCode').hide();
 				Ext.getCmp('editAttributeForm-hideOnSubmission').disable();
 				Ext.getCmp('editAttributeForm-typesRequiredFor').getStore().removeAll();
+				Ext.getCmp('editAttributeForm-associatedComponentTypes').getStore().removeAll();
 			};
 
 
 			var actionEditAttribute = function actionEditAttribute(record) {
 				Ext.getCmp('editAttributeForm-defaultCode').setValue(null);
+				Ext.getCmp('allEntryTypes').setValue(true);
 				Ext.getCmp('requiredFlagCheckBox').setValue(false);
 				Ext.getCmp('editAttributeForm-typesRequiredFor').getStore().removeAll();
+				Ext.getCmp('editAttributeForm-associatedComponentTypes').getStore().removeAll();
 				Ext.getCmp('editAttributeForm').loadRecord(record);
 
 				var requiredEntryTypes = Ext.getCmp('editAttributeForm-typesRequiredFor').getStore();
@@ -310,6 +313,18 @@
 						requiredEntryTypes.add(searchStore.getData().find('code', type.componentType));
 					});
 				}
+
+				// And the same for the associated component types, as well as disabling the 'All' checkbox.
+				if (record.getData().associatedComponentTypes) {
+					Ext.getCmp('allEntryTypes').setValue(false);
+					var associatedComponentTypes = Ext.getCmp('editAttributeForm-associatedComponentTypes').getStore();
+					var allowForTypesSearchStore = Ext.getStore('allowForTypesSearchStore');
+					Ext.Array.each(record.getData().associatedComponentTypes , function(type) {
+						associatedComponentTypes.add(allowForTypesSearchStore.getData().find('code', type.componentType));
+					});
+				} 
+
+
 				editAttributeWin.edit = true;
 				editAttributeWin.setTitle('Edit Attribute - ' + record.data.attributeType);
 				editAttributeWin.show();
@@ -917,8 +932,8 @@
 								style: {
 									margin: '30px'
 								},
-								title: 'Allow For Entry Types (click plus icon to add)',
-								name: 'allowForEntryTypes',
+								title: 'Allow this attribute for these entry types: (click plus icon to add)',
+								name: 'associatedComponentTypes',
 								fieldName: 'description',
 								fieldTitle: 'Entry Type',
 								viewConfig: {
@@ -1017,7 +1032,6 @@
 								style: {
 									margin: '30px'
 								},
-								title: 'Required for entry types (click plus icon to add)',
 								title: 'Require this attribute for these entry types: (click plus icon to add)',
 								name: 'typesRequiredFor',
 								fieldName: 'description',

--- a/server/openstorefront/openstorefront-web/src/main/webapp/WEB-INF/securepages/admin/data/attributes.jsp
+++ b/server/openstorefront/openstorefront-web/src/main/webapp/WEB-INF/securepages/admin/data/attributes.jsp
@@ -895,6 +895,7 @@
 							},
 							{
 								xtype: 'checkboxfield',
+								id: 'allEntryTypes',
 								boxLabel: 'Allow For All Entry Types',
 								value: true,
 								handler: function(box, value) {
@@ -1059,6 +1060,23 @@
 												var data = {};
 												data.attributeType = formData;
 
+												// If we have a set of entry types for which this attribute is associated,
+												// compile them into the consumption format.
+												if (!Ext.getCmp('allEntryTypes').getValue()) { // If box is NOT checked, include the entry type associations.
+													var associatedTypes = Ext.getCmp('editAttributeForm-associatedComponentTypes').getStore().getData().getValues('code','data');
+
+													data.associatedComponentTypes = [];
+
+													Ext.Array.each(associatedTypes, function(type) {
+														data.associatedComponentTypes.push({
+															componentType: type
+														});		
+													});
+												}
+
+
+												// If we have a set of entry types for which this attribute is required,
+												// compile them into the consumption format.
 												if (formData.requiredFlg) {
 													var restrictedTypes = Ext.getCmp('editAttributeForm-typesRequiredFor').getStore().getData().getValues('code','data');
 

--- a/server/openstorefront/openstorefront-web/src/main/webapp/WEB-INF/securepages/admin/data/attributes.jsp
+++ b/server/openstorefront/openstorefront-web/src/main/webapp/WEB-INF/securepages/admin/data/attributes.jsp
@@ -855,15 +855,16 @@
 				id: 'editAttributeWin',
 				title: 'Add/Edit Attribute',
 				modal: true,
-				width: '50%',
-				y: '5em',
+				width: '60%',
+				height: 750,
+				y: '2em',
 				layout: 'fit',
+				autoScroll: true,
 				items: [
 					{
 						xtype: 'form',
 						id: 'editAttributeForm',
-						layout: 'vbox',
-						scrollable: true,
+						autoScroll: true,
 						bodyStyle: 'padding: 10px;',
 						defaults: {
 							labelAlign: 'top',
@@ -930,7 +931,7 @@
 								id: 'editAttributeForm-associatedComponentTypes',
 								hidden: true,
 								style: {
-									margin: '30px'
+									padding: '30px'
 								},
 								title: 'Allow this attribute for these entry types: (click plus icon to add)',
 								name: 'associatedComponentTypes',
@@ -1030,7 +1031,7 @@
 								id: 'editAttributeForm-typesRequiredFor',
 								hidden: true,
 								style: {
-									margin: '30px'
+									padding: '30px'
 								},
 								title: 'Require this attribute for these entry types: (click plus icon to add)',
 								name: 'typesRequiredFor',

--- a/server/openstorefront/openstorefront-web/src/main/webapp/WEB-INF/securepages/admin/data/attributes.jsp
+++ b/server/openstorefront/openstorefront-web/src/main/webapp/WEB-INF/securepages/admin/data/attributes.jsp
@@ -295,18 +295,21 @@
 
 			var actionEditAttribute = function actionEditAttribute(record) {
 				Ext.getCmp('editAttributeForm-defaultCode').setValue(null);
+				Ext.getCmp('requiredFlagCheckBox').setValue(false);
 				Ext.getCmp('editAttributeForm-typesRequiredFor').getStore().removeAll();
 				Ext.getCmp('editAttributeForm').loadRecord(record);
-				var requiredEntryTypes = Ext.getCmp('editAttributeForm-typesRequiredFor').getStore()
-				var searchList = Ext.getCmp('editAttributeForm-typesRequiredFor').getSearch();
 
-				var searchStore = Ext.getStore('requiredTypesSearchStore');
+				var requiredEntryTypes = Ext.getCmp('editAttributeForm-typesRequiredFor').getStore();
 				// Search the searchStore for the record matching the given code,
 				// that way we can display the name of the entry type rather than
 				// just the code.
-				Ext.Array.each(record.requiredRestrictions, function(type) {
-					requiredEntryTypes.add(searchStore.getData().getValues('code', type));
-				});
+				if (record.getData().requiredRestrictions) {
+					Ext.getCmp('requiredFlagCheckBox').setValue(true);
+					var searchStore = Ext.getStore('requiredTypesSearchStore');
+					Ext.Array.each(record.getData().requiredRestrictions, function(type) {
+						requiredEntryTypes.add(searchStore.getData().find('code', type.componentType));
+					});
+				}
 				editAttributeWin.edit = true;
 				editAttributeWin.setTitle('Edit Attribute - ' + record.data.attributeType);
 				editAttributeWin.show();
@@ -951,6 +954,7 @@
 								items: [
 									{
 										name: 'requiredFlg',
+										id: 'requiredFlagCheckBox',
 										boxLabel: 'Required',
 										listeners: {
 											change: function(box, newValue) {
@@ -1014,6 +1018,7 @@
 									margin: '30px'
 								},
 								title: 'Required for entry types (click plus icon to add)',
+								title: 'Require this attribute for these entry types: (click plus icon to add)',
 								name: 'typesRequiredFor',
 								fieldName: 'description',
 								fieldTitle: 'Entry Type',

--- a/server/openstorefront/openstorefront-web/src/main/webapp/WEB-INF/securepages/admin/data/attributes.jsp
+++ b/server/openstorefront/openstorefront-web/src/main/webapp/WEB-INF/securepages/admin/data/attributes.jsp
@@ -294,6 +294,7 @@
 
 
 			var actionEditAttribute = function actionEditAttribute(record) {
+				Ext.getCmp('editAttributeForm-defaultCode').setValue(null);
 				Ext.getCmp('editAttributeForm-typesRequiredFor').getStore().removeAll();
 				Ext.getCmp('editAttributeForm').loadRecord(record);
 				var requiredEntryTypes = Ext.getCmp('editAttributeForm-typesRequiredFor').getStore()

--- a/server/openstorefront/openstorefront-web/src/main/webapp/WEB-INF/securepages/admin/data/components.jsp
+++ b/server/openstorefront/openstorefront-web/src/main/webapp/WEB-INF/securepages/admin/data/components.jsp
@@ -2415,6 +2415,11 @@
 					
 					var requiredAttributes = [];
 					var optionalAttributes = [];
+					// This is slightly difficult to follow,
+					// but the basic gist is that we must check two lists to decide which attributes to show -
+					// requiredRestrictions is a list of types for which the attribute is required
+					// associatedComponentTypes is a list of types for which the attribute is optional
+					// but if associatedComponentTypes is empty, it is optional for all.
 					Ext.Array.each(allAttributes, function(attribute){
 						if (attribute.requiredFlg) {
 							if (attribute.requiredRestrictions) {
@@ -2426,13 +2431,59 @@
 									}
 								});
 								if (found) {
+									// The required flag is set and this entry type is one which requires this attribute.
 									requiredAttributes.push(attribute);
 								}
+								else {
+									// --- Checking for Optional
+									//
+									// In this case, the 'Required' Flag is set but the entry we are dealing with is not an entry
+									// type listed in the requiredRestrictions, i.e. not required for this entry type.
+									// As a result, we need to check if it's allowed as an optional and then add it.
+									// This is the same logic as seen below when the 'Required' flag is off.
+									if (attribute.associatedComponentTypes) {
+										var reqOptFound = Ext.Array.findBy(attribute.associatedComponentTypes, function(item) {
+											if (item.componentType === componentType) {
+												return true;
+											} else {
+												return false;
+											}
+										});
+										if (reqOptFound) {
+											optionalAttributes.push(attribute);
+										}
+									}
+									else {
+										// We have an empty list of associatedComponentTypes, therefore this attribute is
+										// allowed for all entry types.
+										optionalAttributes.push(attribute);
+									}
+									// 
+									// --- End Checking for Optional
+								}
 							} else {
+								// No list of types required for, so it's required for all. Add it.
 								requiredAttributes.push(attribute);
 							}
 						} else {
-							optionalAttributes.push(attribute);
+							if (attribute.associatedComponentTypes) {
+								var optFound = Ext.Array.findBy(attribute.associatedComponentTypes, function(item) {
+									if (item.componentType === componentType) {
+										return true;
+									} else {
+										return false;
+									}
+								});
+								if (optFound) {
+									// This entry type allows this attribute.
+									optionalAttributes.push(attribute);
+								}
+							}
+							else {
+								// We have an empty list of associatedComponentTypes, therefore this attribute is
+								// allowed for all entry types.
+								optionalAttributes.push(attribute);
+							}
 						}
 					});
 					

--- a/server/openstorefront/openstorefront-web/src/main/webapp/client/scripts/component/submissionPanel.js
+++ b/server/openstorefront/openstorefront-web/src/main/webapp/client/scripts/component/submissionPanel.js
@@ -297,7 +297,21 @@ Ext.define('OSF.component.SubmissionPanel', {
 							requiredAttributes.push(attribute);
 						}
 					} else {
-						optionalAttributes.push(attribute);
+						if (attribute.associatedComponentTypes) {
+							var optFound = Ext.Array.findBy(attribute.associatedComponentTypes, function(item){
+								if (item.componentType === componentType) {
+									return true;
+								} else {
+									return false;
+								}
+							});
+							if (optFound) {
+								optionalAttributes.push(attribute);
+							}
+						}
+						else {
+							optionalAttributes.push(attribute);
+						}
 					}
 				}
 			});

--- a/server/openstorefront/openstorefront-web/src/main/webapp/client/scripts/component/submissionPanel.js
+++ b/server/openstorefront/openstorefront-web/src/main/webapp/client/scripts/component/submissionPanel.js
@@ -281,6 +281,11 @@ Ext.define('OSF.component.SubmissionPanel', {
 			var optionalAttributes = [];
 			Ext.Array.each(allAttributes, function(attribute){
 				if (!attribute.hideOnSubmission) {
+					// This is slightly difficult to follow,
+					// but the basic gist is that we must check two lists to decide which attributes to show -
+					// requiredRestrictions is a list of types for which the attribute is required
+					// associatedComponentTypes is a list of types for which the attribute is optional
+					// but if associatedComponentTypes is empty, it is optional for all.
 					if (attribute.requiredFlg) {
 						if (attribute.requiredRestrictions) {
 							var found = Ext.Array.findBy(attribute.requiredRestrictions, function(item){
@@ -293,7 +298,35 @@ Ext.define('OSF.component.SubmissionPanel', {
 							if (found) {
 								requiredAttributes.push(attribute);
 							}
+							else {
+								// --- Checking for Optional
+								//
+								// In this case, the 'Required' Flag is set but the entry we are dealing with is not an entry
+								// type listed in the requiredRestrictions, i.e. not required for this entry type.
+								// As a result, we need to check if it's allowed as an optional and then add it.
+								// This is the same logic as seen below when the 'Required' flag is off.
+								if (attribute.associatedComponentTypes) {
+									var reqOptFound = Ext.Array.findBy(attribute.associatedComponentTypes, function(item) {
+										if (item.componentType === componentType) {
+											return true;
+										} else {
+											return false;
+										}
+									});
+									if (reqOptFound) {
+										optionalAttributes.push(attribute);
+									}
+								}
+								else {
+									// We have an empty list of associatedComponentTypes, therefore this attribute is
+									// allowed for all entry types.
+									optionalAttributes.push(attribute);
+								}
+								// 
+								// --- End Checking for Optional
+							}
 						} else {
+							// No list of types required for, so it's required for all. Add it.
 							requiredAttributes.push(attribute);
 						}
 					} else {
@@ -306,10 +339,13 @@ Ext.define('OSF.component.SubmissionPanel', {
 								}
 							});
 							if (optFound) {
+								// This entry type allows this attribute.
 								optionalAttributes.push(attribute);
 							}
 						}
 						else {
+							// We have an empty list of associatedComponentTypes, therefore this attribute is
+							// allowed for all entry types.
 							optionalAttributes.push(attribute);
 						}
 					}


### PR DESCRIPTION
Allows the user to set the entry types for which an attribute is allowed, in cooperation with allowing the user to set entry types for which an attribute is required. When an attribute is not allowed for an entry type, it will not show up in the list of attributes in the entry submission form.