### PR TITLE
STORE-866 Display a message about unviewable media

### DIFF
--- a/server/openstorefront/openstorefront-web/src/main/webapp/WEB-INF/securepages/admin/data/media.jsp
+++ b/server/openstorefront/openstorefront-web/src/main/webapp/WEB-INF/securepages/admin/data/media.jsp
@@ -192,6 +192,14 @@
 							viewMediaWin.setTitle('Image Preview');
 					        viewMediaWin.update('<img src="../'+ selectedObj.mediaLink+'" width="100%"/>');
 						}
+						else {
+							Ext.Msg.show({
+								title: 'No Preview Available',
+								msg: 'No preview is available for this file format.',
+								buttons: Ext.Msg.OK
+							});
+							return;
+						}
 						
 						viewMediaWin.updateLayout();
 						viewMediaWin.show();


### PR DESCRIPTION
For media types that we can't display a preview for, instead display
a box that informs the user we can't preview the item.