### PR TITLE
Patch 2

### DIFF
--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -697,7 +697,7 @@ Use the following steps to create the agent profile.
 
 Run the following as sudo:
 
-### Optionally install nano. Otherwise use vi.
+### Optionally install nano:
 1)	yum install nano
 
 ### Install Java 1.8:
@@ -708,8 +708,9 @@ Run the following as sudo:
 2)	yum -y update
 3)	yum -y install httpd
 4)	firewall-cmd --permanent --add-port=80/tcp
-5)	firewall-cmd --permanent --add-port=443/tcp
-6)	firewall-cmd --reload
+5)	firewall-cmd --permanent --add-port=8080/tcp
+6)	firewall-cmd --permanent --add-port=443/tcp
+7)	firewall-cmd --reload
 
     NOTE)   If firewall-cmd doesn't exist then run 
 
@@ -719,8 +720,8 @@ Run the following as sudo:
 
     c) systemctl enable firewalld
 
-7)	systemctl start httpd
-8)	systemctl enable httpd
+8)	systemctl start httpd
+9)	systemctl enable httpd
 
 apache service command reference (apache should be running at this point):
 
@@ -728,13 +729,20 @@ apache service command reference (apache should be running at this point):
 
 **Stop:** systemctl stop httpd
 
-**Test:** curl localhost
+**Test:** curl localhost | grep 'Apache HTTP server'
 
-should return a bunch of html to the console
+should give you a response something like this:
+```
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100  4897  100  4897    0     0   928k      0 --:--:-- --:--:-- --:--:--  956k
+                <p class="lead">This page is used to test the proper operation of the <a href="http://apache.org">Apache HTTP server</a> after it has been installed. If you can read this page it means that this site is working properly. This server is powered by <a href="http://centos.org">CentOS</a>.</p>
+```
 
-### Install elasticsearch 2.x
+### Install elasticsearch 2.x:
 1)	rpm --import https://packages.elastic.co/GPG-KEY-elasticsearch
-2)	Add the following in your /etc/yum.repos.d/ directory in a file with a .repo suffix, for example ```/etc/yum.repos.d/elasticsearch.repo```
+2)	Add the following in your /etc/yum.repos.d/ directory in a file with a .repo suffix, 
+for example /etc/yum.repos.d/elasticsearch.repo
 
 ```
 [elasticsearch-2.x]
@@ -747,6 +755,7 @@ enabled=1
 3)	yum install elasticsearch
 4)	systemctl daemon-reload
 5)	systemctl enable elasticsearch.service
+6)	systemctl start elasticsearch.service
 
 elasticsearch service command reference (elasticsearch should be running at this point):
 
@@ -773,10 +782,12 @@ should give you a response something like this:
 }
 ```
 
-### Install tomcat 7 
+### Install tomcat 7:
 (https://www.digitalocean.com/community/tutorials/how-to-install-apache-tomcat-7-on-centos-7-via-yum)
 1)	yum install tomcat
-2)	systemctl enable tomcat
+2)	yum install tomcat-webapps tomcat-admin-webapps 
+3)	systemctl enable tomcat
+4)	systemctl start tomcat
 
 tomcat service command reference (tomcat should be running at this point):
 
@@ -786,11 +797,17 @@ tomcat service command reference (tomcat should be running at this point):
 
 **Install dir:**  /usr/share/tomcat/
 
-**Test:** curl localhost:8080
+**Test:** curl localhost:8080 | grep 'successfully installed Tomcat'
 
-should return a bunch of html to the console
+should give you a response something like this:
+```
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100 11197    0 11197    0     0   850k      0 --:--:-- --:--:-- --:--:--  911k
+                    <h2>If you're seeing this, you've successfully installed Tomcat. Congratulations!</h2>
+```
 
-### Configure Apache proxy 
+### Configure Apache proxy:
 (https://www.digitalocean.com/community/tutorials/how-to-use-apache-as-a-reverse-proxy-with-mod_proxy-on-centos-7)
 1)	Install mod-proxy : already installed	
 2)	Install web socket support: already installed
@@ -800,22 +817,22 @@ should return a bunch of html to the console
 
 ```
 <VirtualHost *:80>
-	   ProxyPreserveHost On	    
-	   RewriteEngine on
+   ProxyPreserveHost On	    
+   RewriteEngine on
 
-	   #Openstorefront
-	    ProxyPass /openstorefront http://localhost:8080/openstorefront
-	    ProxyPassReverse /openstorefront http://localhost:8080/openstorefront
+   #Openstorefront
+   ProxyPass /openstorefront http://localhost:8080/openstorefront
+   ProxyPassReverse /openstorefront http://localhost:8080/openstorefront
 
-	    ProxyPass /openstorefront ws://localhost:8080/openstorefront
-	    ProxyPassReverse /openstorefront ws://localhost:8080/openstorefront
+   ProxyPass /openstorefront ws://localhost:8080/openstorefront
+   ProxyPassReverse /openstorefront ws://localhost:8080/openstorefront
 
-	    RedirectMatch ^/$ /openstorefront/
+   RedirectMatch ^/$ /openstorefront/
 </VirtualHost>
 ```
 4)  systemctl restart httpd
 
-### Configure Tomcat
+### Configure Tomcat:
 
 **Set memory**
 

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -708,9 +708,8 @@ Run the following as sudo:
 2)	yum -y update
 3)	yum -y install httpd
 4)	firewall-cmd --permanent --add-port=80/tcp
-5)	firewall-cmd --permanent --add-port=8080/tcp
-6)	firewall-cmd --permanent --add-port=443/tcp
-7)	firewall-cmd --reload
+5)	firewall-cmd --permanent --add-port=443/tcp
+6)	firewall-cmd --reload
 
     NOTE)   If firewall-cmd doesn't exist then run 
 
@@ -720,8 +719,8 @@ Run the following as sudo:
 
     c) systemctl enable firewalld
 
-8)	systemctl start httpd
-9)	systemctl enable httpd
+7)	systemctl start httpd
+8)	systemctl enable httpd
 
 apache service command reference (apache should be running at this point):
 
@@ -820,17 +819,23 @@ should give you a response something like this:
    ProxyPreserveHost On	    
    RewriteEngine on
 
-   #Openstorefront
-   ProxyPass /openstorefront http://localhost:8080/openstorefront
-   ProxyPassReverse /openstorefront http://localhost:8080/openstorefront
-
-   ProxyPass /openstorefront ws://localhost:8080/openstorefront
-   ProxyPassReverse /openstorefront ws://localhost:8080/openstorefront
-
+   # Openstorefront reverse proxy
+   ProxyPass "/openstorefront/" "http://localhost:8080/openstorefront/"
+   ProxyPassReverse "/openstorefront/" "http://localhost:8080/openstorefront/"
+   
+   # Openstorefront web socket reverse proxy
+   ProxyPass "/openstorefront/" "ws://localhost:8080/openstorefront/"
+   ProxyPassReverse "/openstorefront/" ws://localhost:8080/openstorefront/"
+   
+   # changes <hostname>/ to <hostname>/openstorefront/
    RedirectMatch ^/$ /openstorefront/
 </VirtualHost>
 ```
-4)  systemctl restart httpd
+4)	If you have SELinux running (which is installed by default on CentOS) then we need the instructions from here (http://sysadminsjourney.com/content/2010/02/01/apache-modproxy-error-13permission-denied-error-rhel/)
+
+    a)	/usr/sbin/setsebool -P httpd_can_network_connect 1
+    
+5) 	systemctl restart httpd
 
 ### Configure Tomcat:
 

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -867,3 +867,4 @@ JAVA_OPTS="-Djava.security.egd=file:/dev/./urandom -Djava.awt.headless=true -Xmx
     example: ```curl -LO https://github.com/di2e/openstorefront/releases/download/v2.3/openstorefront.war```
 4)	chown tomcat:tomcat openstorefront.war
 5)	mv openstorefront.war /usr/share/tomcat/webapps 
+6) 	systemctl restart tomcat

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -866,4 +866,4 @@ JAVA_OPTS="-Djava.security.egd=file:/dev/./urandom -Djava.awt.headless=true -Xmx
 	
     example: ```curl -LO https://github.com/di2e/openstorefront/releases/download/v2.3/openstorefront.war```
 4)	chown tomcat:tomcat openstorefront.war
-5)	mv -a openstorefront.war /usr/share/tomcat/webapps 
+5)	mv openstorefront.war /usr/share/tomcat/webapps 

--- a/docs/Setup.md
+++ b/docs/Setup.md
@@ -825,7 +825,7 @@ should give you a response something like this:
    
    # Openstorefront web socket reverse proxy
    ProxyPass "/openstorefront/" "ws://localhost:8080/openstorefront/"
-   ProxyPassReverse "/openstorefront/" ws://localhost:8080/openstorefront/"
+   ProxyPassReverse "/openstorefront/" "ws://localhost:8080/openstorefront/"
    
    # changes <hostname>/ to <hostname>/openstorefront/
    RedirectMatch ^/$ /openstorefront/


### PR DESCRIPTION
Updated setup.md file to open port 8080, correct some typos, and add a final restart of Tomcat. 

NOTE: The Apache port forwarding doesn't work. going to http://ip.address redirects to http://ip.address/openstorefront/ but then says the site is unavailable. Going to http://ip.address:8080 shows the tomcat landing page. To get to the site you have to go to http://ip.address:8080/openstorefront 

Tested on CentOS 7 Minimal Install on a local VM.