### PR TITLE
STORE-1882

### DIFF
--- a/server/openstorefront/openstorefront-web/src/main/webapp/WEB-INF/securepages/admin/data/highlights.jsp
+++ b/server/openstorefront/openstorefront-web/src/main/webapp/WEB-INF/securepages/admin/data/highlights.jsp
@@ -325,7 +325,7 @@
 				var highlightAddEditWin = Ext.create('Ext.window.Window', {
 					id: 'highlightAddEditWin',
 					title: 'Add/Edit Highlight',
-					minHeight: 750,
+					height: '70%',
 					minWidth: 700,
 					modal: true,
 					scrollable: true,


### PR DESCRIPTION
Fix: When the height of the browser window is smaller than that of the 'Add/Edit Highlight' window, the window is cut off.