### PR TITLE
STORE-2056

### DIFF
--- a/server/openstorefront/openstorefront-web/src/main/webapp/OSF/form/ChecklistQuestion.js
+++ b/server/openstorefront/openstorefront-web/src/main/webapp/OSF/form/ChecklistQuestion.js
@@ -200,61 +200,76 @@ Ext.define('OSF.form.ChecklistQuestion', {
 				questionForm.setLoading(false);
 			}, 
 			success: function(response, localOpts) {
-				var responseData = Ext.decode(response.responseText);
-				
-				questionForm.response.getComponent('question').update(responseData.question);
-
-				var record = Ext.create('Ext.data.Model', {			
-				});
-				record.set(responseData);	
-
-				questionForm.loadRecord(record);
-				questionForm.evaluationId = evaluationId;
-				questionForm.checklistResponse = responseData;
-
-				if (opts && opts.mainForm) {
-					questionForm.refreshCallback = opts.mainForm.refreshCallback;
-				}		
-
-				//Add change detection
 				Ext.defer(function(){
-					questionForm.getComponent('tools').getComponent('workflowStatus').on('change', function(field, newValue, oldValue){
-						questionForm.saveData();
-					}, undefined, {
-						buffer: 1000
-					});
+					var responseData = Ext.decode(response.responseText);
+					var questionFormComponentExists = true;
 
-					questionForm.response.getComponent('score').on('change', function(field, newValue, oldValue){
-						questionForm.markUnsaved();
-					}, undefined, {
-						buffer: 1000
-					});
+					// Check and see if the form component exists.
+					try {
+						questionForm.response.getComponent('question');
+						questionForm.getComponent('tools').getComponent('workflowStatus');
+						questionForm.response.getComponent('notApplicable');
+						questionForm.response.getComponent('score');
+						questionForm.response.getComponent('response');
+						questionForm.response.getComponent('privateNote');
+					} catch (e) {
+						questionFormComponentExists = false;
+					}
 					
-					questionForm.response.getComponent('notApplicable').on('change', function(field, newValue, oldValue){
-						var scoreField = questionForm.response.getComponent('score');
-						if (newValue) {
-							scoreField.setValue(null);
-							scoreField.setDisabled(true);
-						} else {
-							scoreField.setDisabled(false);
-							questionForm.markUnsaved();	
-						}
-					}, undefined, {
-						buffer: 1000
-					});					
+					if (questionFormComponentExists) {
+						questionForm.response.getComponent('question').update(responseData.question);
 
-					questionForm.response.getComponent('response').on('change', function(field, newValue, oldValue){
-						questionForm.markUnsaved();
-					}, undefined, {
-						buffer: 2000
-					});
+						var record = Ext.create('Ext.data.Model', {			
+						});
+						record.set(responseData);	
 
-					questionForm.response.getComponent('privateNote').on('change', function(field, newValue, oldValue){
-						questionForm.markUnsaved();
-					}, undefined, {
-						buffer: 2000
-					});					
-				}, 1000);
+						questionForm.loadRecord(record);
+						questionForm.evaluationId = evaluationId;
+						questionForm.checklistResponse = responseData;
+
+						if (opts && opts.mainForm) {
+							questionForm.refreshCallback = opts.mainForm.refreshCallback;
+						}		
+
+					//Add change detection
+						questionForm.getComponent('tools').getComponent('workflowStatus').on('change', function(field, newValue, oldValue){
+							questionForm.saveData();
+						}, undefined, {
+							buffer: 1000
+						});
+
+						questionForm.response.getComponent('score').on('change', function(field, newValue, oldValue){
+							questionForm.markUnsaved();
+						}, undefined, {
+							buffer: 1000
+						});
+						
+						questionForm.response.getComponent('notApplicable').on('change', function(field, newValue, oldValue){
+							var scoreField = questionForm.response.getComponent('score');
+							if (newValue) {
+								scoreField.setValue(null);
+								scoreField.setDisabled(true);
+							} else {
+								scoreField.setDisabled(false);
+								questionForm.markUnsaved();	
+							}
+						}, undefined, {
+							buffer: 1000
+						});					
+
+						questionForm.response.getComponent('response').on('change', function(field, newValue, oldValue){
+							questionForm.markUnsaved();
+						}, undefined, {
+							buffer: 2000
+						});
+
+						questionForm.response.getComponent('privateNote').on('change', function(field, newValue, oldValue){
+							questionForm.markUnsaved();
+						}, undefined, {
+							buffer: 2000
+						});					
+					}
+				}, 100);
 			}
 		});
 				


### PR DESCRIPTION
Fix: when a user clicks on a checklist question within roughly one second of clicking on another, a javascript error is thrown.

NOTE: unfortunately there is no concrete way to check the state of the form component, thus I needed to resort to a try catch statement.
It is also important to note that this timing issue is also effecting other areas of code (especially if the tinymce text area is populated.) We might consider fixing this at a later date. However, these JS errors are not breaking anything.