### PR TITLE
STORE-2237

### DIFF
--- a/server/openstorefront/openstorefront-web/src/main/webapp/WEB-INF/securepages/admin/evaluation/evaluations.jsp
+++ b/server/openstorefront/openstorefront-web/src/main/webapp/WEB-INF/securepages/admin/evaluation/evaluations.jsp
@@ -211,6 +211,11 @@
 							},
 							{
 								xtype: 'checkbox',
+								name: 'allowNewSubSections',
+								boxLabel: 'Allow Adding Sub Sections'
+							},
+							{
+								xtype: 'checkbox',
 								name: 'allowQuestionManagement',
 								boxLabel: 'Allow Question Management'
 							}							


### PR DESCRIPTION
HOTFIX: A new field 'allNewSubSections' did not have a checkbox on the form for creating a new evaluation.