### PR TITLE
STORE-2146 

### DIFF
--- a/server/openstorefront/openstorefront-web/src/main/webapp/OSF/form/Media.js
+++ b/server/openstorefront/openstorefront-web/src/main/webapp/OSF/form/Media.js
@@ -56,6 +56,7 @@ Ext.define('OSF.form.Media', {
 						var data = mainForm.getValues();
 						var componentId = mediaPanel.mediaGrid.componentId;
 
+						data.caption = data.caption.replace(/\"|\'/g, '');
 						data.fileSelected = mainForm.getComponent('upload').getValue();
 						data.link = data.originalLink;
 						data.originalName = data.originalFileName;


### PR DESCRIPTION
Fix: Media will not open in an entry's carousel if the caption contains a quotation mark.