### PR TITLE
STORE-1973 - Get undefined on duplicate tags where they are not saved until an assignment is made

### DIFF
--- a/server/openstorefront/openstorefront-web/src/main/webapp/WEB-INF/securepages/admin/data/user-data/tags.jsp
+++ b/server/openstorefront/openstorefront-web/src/main/webapp/WEB-INF/securepages/admin/data/user-data/tags.jsp
@@ -1101,7 +1101,7 @@
 											fn: function(field, newValue, oldValue, eOpts) {
 												
 												// Lookup New Value Against Existing Tags
-												var matchingTags = store_tags_local.query('name', newValue, false, false, true);
+												var matchingTags = store_tags_local.query('name', new RegExp('^[\*]?' + newValue + '$', 'i'), false, false, true);
 												
 												// Store Save Button
 												var saveButton = Ext.getCmp('addTagForm-saveButton');


### PR DESCRIPTION
Fix: Error occurs when NEW duplicate tags are assigned to entries.