### PR TITLE
STORE-1941 - Sort by relevance does not appear to be turned on by default

### DIFF
--- a/server/openstorefront/openstorefront-core/model/src/main/java/edu/usu/sdl/openstorefront/core/sort/RelevanceComparator.java
+++ b/server/openstorefront/openstorefront-core/model/src/main/java/edu/usu/sdl/openstorefront/core/sort/RelevanceComparator.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2017 Space Dynamics Laboratory - Utah State University Research Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.usu.sdl.openstorefront.core.sort;
+
+import edu.usu.sdl.openstorefront.core.view.ComponentSearchView;
+import java.util.Comparator;
+
+/**
+ *
+ * @author cyearsley
+ * @param <T>
+ * 
+ */
+public class RelevanceComparator<T extends ComponentSearchView>
+		implements Comparator<T>
+{
+	public RelevanceComparator()
+	{
+	}
+	
+	@Override
+	public int compare(T o1, T o2)
+	{
+		if (o1 == null && o2 == null) {
+			return 0;
+		} else if (o1 != null && o2 == null) {
+			return 1;
+		} else if (o1 == null && o2 != null) {
+			return -1;
+		} else if (o1.getSearchScore() == o2.getSearchScore()) {
+			
+			//	Ascending
+			return o1.getName().compareTo(o2.getName());
+		} else {
+			
+			//	Descending
+			return o1.getSearchScore() > o2.getSearchScore() ? -1 : 1;
+		}
+	}
+}

--- a/server/openstorefront/openstorefront-core/model/src/main/java/edu/usu/sdl/openstorefront/core/view/ComponentSearchView.java
+++ b/server/openstorefront/openstorefront-core/model/src/main/java/edu/usu/sdl/openstorefront/core/view/ComponentSearchView.java
@@ -41,6 +41,7 @@ public class ComponentSearchView
 {
 	public static final String FIELD_NAME = "name";
 	public static final String FIELD_ORGANIZATION = "organization";
+	public static final String FIELD_SEARCH_SCORE = "searchScore";
 	
 	private String listingType;
 	private String componentId;

--- a/server/openstorefront/openstorefront-core/model/src/test/java/edu/usu/sdl/openstorefront/sort/RelevanceComparatorTest.java
+++ b/server/openstorefront/openstorefront-core/model/src/test/java/edu/usu/sdl/openstorefront/sort/RelevanceComparatorTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2017 Space Dynamics Laboratory - Utah State University Research Foundation.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package edu.usu.sdl.openstorefront.sort;
+
+import edu.usu.sdl.openstorefront.core.sort.RelevanceComparator;
+import edu.usu.sdl.openstorefront.core.view.ComponentSearchView;
+import java.util.Arrays;
+import java.util.Collection;
+import junit.framework.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+/**
+ *
+ * Tests the compare method for the RelevanceComparator
+ * Use case: Collections.sort(views, new RelevanceComparator<>());
+ * @author cyearsley
+ */
+@RunWith(Parameterized.class)
+public class RelevanceComparatorTest
+{
+	private final ComponentSearchView view1, view2;
+	private final int expectedOutput;
+	
+	public RelevanceComparatorTest (ComponentSearchView view1, ComponentSearchView view2, int expectedOutput)
+	{
+		this.view1 = view1;
+		this.view2 = view2;
+		this.expectedOutput = expectedOutput;
+	}
+	
+	@Parameterized.Parameters
+	public static Collection<Object[]> generateData()
+	{
+		// Setup
+		ComponentSearchView nullComp = null;
+		ComponentSearchView view1 = new ComponentSearchView();
+		ComponentSearchView view2 = new ComponentSearchView();
+		ComponentSearchView view3 = new ComponentSearchView();
+		ComponentSearchView view4 = new ComponentSearchView();
+		
+		// Same name, different scores
+		view1.setSearchScore(1);
+		view1.setName("a");
+		view2.setSearchScore(5);
+		view2.setName("a");
+		
+		// Different name, same score
+		view3.setSearchScore(10);
+		view3.setName("x");
+		view4.setSearchScore(10);
+		view4.setName("y");
+		
+		// Test as many permutations as the RelevanceComparator considers.
+		return Arrays.asList(new Object[][] {
+			// compare nulls
+			{nullComp, nullComp, 0},
+			
+			// compare not null and null views
+			{view1, nullComp, 1},
+			
+			// compare null and not null views
+			{nullComp, view1, -1},
+			
+			// compare same scores where arg1 name has higher alphabetical order than arg2 name
+			{view3, view4, -1},
+			
+			// compare same scores where arg2 name has higher alphabetical order than arg1 name
+			{view4, view3, 1},
+			
+			// compare same names where arg1 has lower scores than arg2
+			{view1, view2, 1},
+			
+			// compare same names where arg2 has lower scores than arg1
+			{view2, view1, -1},
+			
+			// compare different score and name (produces positive)
+			{view4, view2, -1}
+		});
+	}
+	
+	@Test
+	public void testCompare()
+	{
+		// Setup
+		RelevanceComparator comparator = new RelevanceComparator();
+		
+		// Act
+		int result = comparator.compare(view1, view2);
+		
+		// Assert
+		Assert.assertEquals(expectedOutput, result);
+	}
+}

--- a/server/openstorefront/openstorefront-core/service/src/main/java/edu/usu/sdl/openstorefront/service/SearchServiceImpl.java
+++ b/server/openstorefront/openstorefront-core/service/src/main/java/edu/usu/sdl/openstorefront/service/SearchServiceImpl.java
@@ -398,7 +398,8 @@ public class SearchServiceImpl
 					Collections.sort(views, new BeanComparator<>(searchModel.getSortDirection(), searchModel.getSortField()));
 				}
 				
-				if (StringUtils.isNotBlank(searchModel.getSortField()) && "searchScore".equals(searchModel.getSortField())) {
+				//	Order by relevance then name
+				if (StringUtils.isNotBlank(searchModel.getSortField()) && ComponentSearchView.FIELD_SEARCH_SCORE.equals(searchModel.getSortField())) {
 					Collections.sort(views, new RelevanceComparator<>());
 				}
 

--- a/server/openstorefront/openstorefront-core/service/src/main/java/edu/usu/sdl/openstorefront/service/SearchServiceImpl.java
+++ b/server/openstorefront/openstorefront-core/service/src/main/java/edu/usu/sdl/openstorefront/service/SearchServiceImpl.java
@@ -37,6 +37,7 @@ import edu.usu.sdl.openstorefront.core.model.search.SearchOperation.MergeConditi
 import edu.usu.sdl.openstorefront.core.model.search.SearchOperation.SearchType;
 import edu.usu.sdl.openstorefront.core.model.search.SearchSuggestion;
 import edu.usu.sdl.openstorefront.core.sort.BeanComparator;
+import edu.usu.sdl.openstorefront.core.sort.RelevanceComparator;
 import edu.usu.sdl.openstorefront.core.util.TranslateUtil;
 import edu.usu.sdl.openstorefront.core.view.ComponentSearchView;
 import edu.usu.sdl.openstorefront.core.view.ComponentSearchWrapper;
@@ -392,9 +393,13 @@ public class SearchServiceImpl
 					String indexQuery = indexSearches.get(0).getValue();
 					SearchServerManager.updateSearchScore(indexQuery, views);
 				}
-
+				
 				if (StringUtils.isNotBlank(searchModel.getSortField())) {
 					Collections.sort(views, new BeanComparator<>(searchModel.getSortDirection(), searchModel.getSortField()));
+				}
+				
+				if (StringUtils.isNotBlank(searchModel.getSortField()) && "searchScore".equals(searchModel.getSortField())) {
+					Collections.sort(views, new RelevanceComparator<>());
 				}
 
 				//trim descriptions to max length

--- a/server/openstorefront/openstorefront-web/src/main/webapp/searchResults.jsp
+++ b/server/openstorefront/openstorefront-web/src/main/webapp/searchResults.jsp
@@ -123,7 +123,7 @@
 
 			var savedSearchId = '${param.savedSearchId}';
 			
-			var maxPageSize = 300;
+			var maxPageSize = 30;
 			
 			var notificationWin = Ext.create('OSF.component.NotificationWindow', {				
 			});	
@@ -624,7 +624,7 @@
 					rating: Ext.getCmp('filterByRating').getValue(),
 					sortBy: Ext.getCmp('sortByCB').getSelection() ? Ext.getCmp('sortByCB').getSelection().data : null,
 					attributes: attributeFilters
-				};				
+				};
 				
 				//determine client side or server-side
 				if (filterMode === 'CLIENT') {
@@ -1191,6 +1191,8 @@
 								typeAhead: false,
 								displayField: 'label',
 								valueField: 'fieldCode',
+								forceSelection: true,
+								value: 'searchScore',
 								listeners: {
 									change: function(cb, newValue, oldValue, opts) {
 										filterResults();
@@ -1479,7 +1481,12 @@
 											exportForm.submit();
 										}
 									}
-								]
+								],
+								listeners: {
+									change: function (me) {
+										Ext.getCmp('resultsDisplayPanel').body.scrollTo('top', 0);
+									}
+								}
 							})
 						]						
 					}
@@ -1744,6 +1751,7 @@
 		
 			//Load 
 			performSearch();
+			filterResults();
 		
 		});
 		


### PR DESCRIPTION
Improvement: should search by relevance by default. Improvement: Search by relevance orders by relevance then name. Improvement: when changing search result paging, scroll to top of result window.