### PR TITLE
STORE-2103 - Add PDF output support for Entry Details

### DIFF
--- a/server/openstorefront/openstorefront-core/service/src/main/java/edu/usu/sdl/openstorefront/report/generator/BaseGenerator.java
+++ b/server/openstorefront/openstorefront-core/service/src/main/java/edu/usu/sdl/openstorefront/report/generator/BaseGenerator.java
@@ -74,7 +74,6 @@ public abstract class BaseGenerator
 					log.log(Level.WARNING, "Unable to cleanup failed report.", ex);
 				}
 			}
-			throw new OpenStorefrontRuntimeException("The report failed to run.");
 		}
 	}
 

--- a/server/openstorefront/openstorefront-core/service/src/test/java/edu/usu/sdl/openstorefront/service/BaseGeneratorTest.java
+++ b/server/openstorefront/openstorefront-core/service/src/test/java/edu/usu/sdl/openstorefront/service/BaseGeneratorTest.java
@@ -140,14 +140,9 @@ public class BaseGeneratorTest
 		//	Check both states of the file, before and after finish method is called.
 		//	Check the "Failed" state of the report is toggled to true
 		//		as it was set to "false" in the "internalFinish" method.
-		try {
-			Assert.assertEquals(Boolean.TRUE, (Boolean) new File(pathToReport.toString()).exists());
-			generatorExample.finish();
-			Assert.fail();
-		}
-		catch (Exception e) {
-			Assert.assertEquals(Boolean.TRUE, (Boolean) generatorExample.isFailed());
-			Assert.assertEquals(Boolean.FALSE, (Boolean) new File(pathToReport.toString()).exists());
-		}
+		Assert.assertEquals(Boolean.TRUE, (Boolean) new File(pathToReport.toString()).exists());
+		generatorExample.finish();
+		Assert.assertEquals(Boolean.TRUE, (Boolean) generatorExample.isFailed());
+		Assert.assertEquals(Boolean.FALSE, (Boolean) new File(pathToReport.toString()).exists());
 	}
 }


### PR DESCRIPTION
Fix: An error exception was block a more critical error exception (the latter is far more verbose and helpful.) DEBUG: this needs to be merged and pushed to store accept to see what the problem is exactly (as it is a data problem.)