### PR TITLE
STORE-2437 - Adding external Media/Resource Link Broken

### DIFF
--- a/server/openstorefront/openstorefront-web/src/main/webapp/OSF/form/Media.js
+++ b/server/openstorefront/openstorefront-web/src/main/webapp/OSF/form/Media.js
@@ -177,8 +177,7 @@ Ext.define('OSF.form.Media', {
 					itemId: 'upload',
 					resourceLabel: 'Upload Media',
 					name: 'file',
-					width: '100%',
-					allowBlank: false
+					width: '100%'
 				},
 				{
 					xtype: 'textfield',

--- a/server/openstorefront/openstorefront-web/src/main/webapp/OSF/form/Resources.js
+++ b/server/openstorefront/openstorefront-web/src/main/webapp/OSF/form/Resources.js
@@ -183,8 +183,7 @@ Ext.define('OSF.form.Resources', {
 					itemId: 'upload',
 					name: 'file',
 					width: '100%',
-					resourceLabel: 'Upload Resource',
-					allowBlank: false
+					resourceLabel: 'Upload Resource'
 				},
 				Ext.create('OSF.component.SecurityComboBox', {						
 				}),

--- a/server/openstorefront/openstorefront-web/src/main/webapp/scripts/component/standardComponents.js
+++ b/server/openstorefront/openstorefront-web/src/main/webapp/scripts/component/standardComponents.js
@@ -268,7 +268,7 @@ Ext.define('OSF.component.fileFieldMaxLabel', {
 	alias: 'widget.fileFieldMaxLabel',
 	extend: 'Ext.form.field.File',
 
-	resourceLabel: 'Upload Rescource',
+	resourceLabel: 'Upload Resource',
 	checkFileLimit: true,
 	displayFileLimit: true,
 

--- a/server/openstorefront/openstorefront-web/src/main/webapp/scripts/component/submissionPanel.js
+++ b/server/openstorefront/openstorefront-web/src/main/webapp/scripts/component/submissionPanel.js
@@ -1415,7 +1415,7 @@ Ext.define('OSF.component.SubmissionPanel', {
 								itemId: 'upload',
 								name: 'file',
 								width: '100%',
-								allowBlank: false
+								hidden: true
 							},
 							Ext.create('OSF.component.SecurityComboBox', {
 								itemId: 'securityMarkings',
@@ -1634,8 +1634,7 @@ Ext.define('OSF.component.SubmissionPanel', {
 								itemId: 'upload',
 								name: 'file',
 								width: '100%',
-								resourceLabel: 'Upload Media',
-								allowBlank: false
+								resourceLabel: 'Upload Media'
 							},
 							{
 								xtype: 'textfield',


### PR DESCRIPTION
Fix: when a form gives the option for either a local or external resource, the form still set local as required (should be optional). Fix: fixed a typo in the fileFieldMaxLabel component default label. Fix: On the submission form for media, when the form is first displayed, both the local and external fields are visible (it should be one or the other.)