### PR TITLE
STORE-2409 - Evaluation Copy - Copied evaluation tag form errors out

### DIFF
--- a/server/openstorefront/openstorefront-web/src/main/webapp/OSF/form/Tags.js
+++ b/server/openstorefront/openstorefront-web/src/main/webapp/OSF/form/Tags.js
@@ -93,7 +93,7 @@ Ext.define('OSF.form.Tags', {
 							items: [
 								Ext.create('OSF.component.StandardComboBox', {
 									name: 'text',	
-									id: 'tagField',																				
+									itemId: 'tagField',
 									flex: 1,
 									fieldLabel: 'Add Tag',
 									forceSelection: false,
@@ -120,7 +120,7 @@ Ext.define('OSF.form.Tags', {
 									margin: '30 0 0 0',
 									minWidth: 75,
 									handler: function(){
-										var tagField = Ext.getCmp('tagField');
+										var tagField = this.findParentByType('form').query('[name="text"]')[0];
 										if (tagField.isValid()) {
 											actionAddTag(this.up('form'));
 										}


### PR DESCRIPTION
Fix: When opening the evaluation form and viewing the 'tags' tab, an error is thrown if the 'tags' tab had already been viewed in another window.