### PR TITLE
STORE-2442 - Bug: Link to Icon shows missing media in search results

### DIFF
--- a/server/openstorefront/openstorefront-web/src/main/webapp/OSF/form/Media.js
+++ b/server/openstorefront/openstorefront-web/src/main/webapp/OSF/form/Media.js
@@ -184,7 +184,18 @@ Ext.define('OSF.form.Media', {
 					fieldLabel: 'Link',																																	
 					maxLength: '255',									
 					emptyText: 'http://www.example.com/image.png',
-					name: 'originalLink'
+					name: 'originalLink',
+					listeners: {
+						change: function (self, newVal, oldVal) {
+							var iconCheckbox = self.up().query('[name="iconFlag"]')[0];
+							if (newVal === '') {
+								iconCheckbox.setDisabled(false);
+							}
+							else {
+								iconCheckbox.setDisabled(true);
+							}
+						}
+					}
 				},
 				{
 					xtype: 'checkbox',
@@ -198,7 +209,7 @@ Ext.define('OSF.form.Media', {
 				},
 				{
 					xtype: 'checkbox',
-					fieldLabel: 'Icon <i class="fa fa-question-circle"  data-qtip="Designates a media item to be used as an icon. There should only be one active on a entry at a time."></i>',
+					fieldLabel: 'Icon <i class="fa fa-question-circle"  data-qtip="Designates a media item to be used as an icon. There should only be one active on a entry at a time. You <b>cannot</b> use a <b>Link</b> or external media for the icon."></i>',
 					name: 'iconFlag'
 				},				
 				Ext.create('OSF.component.SecurityComboBox', {					

--- a/server/openstorefront/openstorefront-web/src/main/webapp/scripts/component/submissionPanel.js
+++ b/server/openstorefront/openstorefront-web/src/main/webapp/scripts/component/submissionPanel.js
@@ -1616,6 +1616,8 @@ Ext.define('OSF.component.SubmissionPanel', {
 											button.setText('Local Resource');
 											form.getForm().findField('file').setHidden(false);
 											form.getForm().findField('originalLink').setHidden(true);
+											
+											form.query('[name="iconFlag"]')[0].setDisabled(false);
 										}
 									},
 									{
@@ -1626,6 +1628,8 @@ Ext.define('OSF.component.SubmissionPanel', {
 											button.setText('External Link');
 											form.getForm().findField('file').setHidden(true);
 											form.getForm().findField('originalLink').setHidden(false);
+											
+											form.query('[name="iconFlag"]')[0].setDisabled(true);
 										}
 									}
 								]


### PR DESCRIPTION
Fix: Icons are broken when they are uploaded as external media.
This was fixed by disabling the icon checkbox when specifying external media.